### PR TITLE
notification: Remove Vala placeholder file

### DIFF
--- a/demos/Notification/main.vala
+++ b/demos/Notification/main.vala
@@ -1,2 +1,0 @@
-// Sorry, this demo is not available in Vala yet.
-// see https://github.com/workbenchdev/Workbench/issues/110


### PR DESCRIPTION
It made sense to have this placeholder in the past as Workbench showed a similar message when a demo was not available. This is no longer the case, and it now only makes the library show that Vala is available, when it isn't.