### PR TITLE
Add HTTP Server demo

### DIFF
--- a/demos/HTTP Server/main.blp
+++ b/demos/HTTP Server/main.blp
@@ -1,0 +1,17 @@
+using Gtk 4.0;
+using Adw 1;
+
+Adw.StatusPage {
+  title: "HTTP Server";
+  description: _("Create a simple HTTP server");
+
+  ToggleButton button_server {
+    halign: center;
+    label: _("Start Server");
+
+    styles [
+      "pill"
+    ]
+  }
+}
+

--- a/demos/HTTP Server/main.js
+++ b/demos/HTTP Server/main.js
@@ -1,0 +1,55 @@
+import Soup from "gi://Soup";
+
+function handler(_server, msg, _path, _query) {
+  msg.set_status(200, null);
+  msg
+    .get_response_headers()
+    .set_content_type("text/html", { charset: "UTF-8" });
+  msg.get_response_body().append(`
+        <html>
+        <body>
+            Greetings, visitor from ${msg.get_remote_host()}<br>
+            What is your name?
+            <form action="/hello">
+                <input name="myname">
+            </form>
+        </body>
+        </html>
+    `);
+}
+
+function helloHandler(_server, msg, path, query) {
+  if (!query) {
+    msg.set_redirect(302, "/");
+    return;
+  }
+
+  msg.set_status(200, null);
+  msg
+    .get_response_headers()
+    .set_content_type("text/html", { charset: "UTF-8" });
+  msg.get_response_body().append(`
+        <html>
+        <body>
+            Hello, ${query.myname}! ☺<br>
+            <a href="/">Go back</a>
+        </body>
+        </html>
+    `);
+}
+
+let button_server = workbench.builder.get_object("button_server");
+
+let server = new Soup.Server();
+server.add_handler("/", handler);
+server.add_handler("/hello", helloHandler);
+
+button_server.connect("clicked", () => {
+  if (button_server.active) {
+    server.listen_local(1080, Soup.ServerListenOptions.IPV4_ONLY);
+    button_server.label = "Stop Server";
+  } else {
+    server.disconnect();
+    button_server.label = "Start Server";
+  }
+});

--- a/demos/HTTP Server/main.json
+++ b/demos/HTTP Server/main.json
@@ -1,0 +1,6 @@
+{
+  "category": "network",
+  "description": "Create a simple HTTP server",
+  "panels": ["code", "preview"],
+  "autorun": true
+}


### PR DESCRIPTION
Closes #19

I didn't add a comment because `server` is not being picked by the GC when it's being used inside the signal handler. 