### PR TITLE
Port 'HTTP Request' demo to Python

### DIFF
--- a/demos/HTTP Request/main.js
+++ b/demos/HTTP Request/main.js
@@ -31,8 +31,8 @@ async function fetchWikipediaTodaysFeaturedArticle() {
     null,
   );
 
-  if (message.status_code !== 200) {
-    console.error(`HTTP Status ${message.status_code}`);
+  if (message.get_status() !== Soup.Status.OK) {
+    console.error(`HTTP Status ${message.get_status()}`);
     return;
   }
 

--- a/demos/HTTP Request/main.py
+++ b/demos/HTTP Request/main.py
@@ -1,0 +1,39 @@
+import gi
+
+gi.require_version("Soup", "3.0")
+from gi.repository import GLib, Soup
+import workbench
+import json
+
+http_session = Soup.Session()
+article_text_view = workbench.builder.get_object("article_text_view")
+article_title = workbench.builder.get_object("article_title")
+
+
+def fetch_wikipedia_todays_featured_article():
+    # https://gjs-docs.gnome.org/glib20~2.0/glib.datetime
+    date = GLib.DateTime.new_now_local()
+
+    # https://api.wikimedia.org/wiki/Feed_API/Reference/Featured_content
+    language = "en"
+    url = f"https://api.wikimedia.org/feed/v1/wikipedia/{language}/featured/{date.format('%Y/%m/%d')}"
+    message = Soup.Message.new("GET", url)
+
+    http_session.send_and_read_async(
+        message, GLib.PRIORITY_DEFAULT, None, on_receive_bytes, message
+    )
+
+
+def on_receive_bytes(session, result, message):
+    if message.get_status() != Soup.Status.OK:
+        print(f"HTTP Status {message.get_status()}")
+        return
+
+    bytes = session.send_and_read_finish(result)
+    decoded_text = bytes.unref_to_array().decode("utf-8")
+    json_dict = json.loads(decoded_text)
+    article_text_view.get_buffer().set_text(json_dict["tfa"]["extract"], -1)
+    article_title.set_label(json_dict["tfa"]["titles"]["normalized"])
+
+
+fetch_wikipedia_todays_featured_article()

--- a/demos/HTTP Request/main.vala
+++ b/demos/HTTP Request/main.vala
@@ -24,8 +24,9 @@ private async void fetch_wikipedia_todays_featured_article () throws Error {
 
     // https://api.wikimedia.org/wiki/Feed_API/Reference/Featured_content
     string language = "en";
+    string date_string = date.format ("%Y/%m/%d");
     string url =
-        @"https://api.wikimedia.org/feed/v1/wikipedia/$language/featured/$(date.format (" % Y / % m / % d "))";
+        @"https://api.wikimedia.org/feed/v1/wikipedia/$language/featured/$(date_string)";
 
     var message = new Soup.Message ("GET", url);
 

--- a/demos/HTTP Request/main.vala
+++ b/demos/HTTP Request/main.vala
@@ -32,8 +32,8 @@ private async void fetch_wikipedia_todays_featured_article () throws Error {
 
     Bytes message_bytes = yield http_session.send_and_read_async (message, Priority.DEFAULT, null);
 
-    if (message.status_code != 200) {
-        throw new FetchError.FAILED_REQUEST (@"Failed Request. HTTP Status: $(message.status_code)");
+    if (message.get_status () != Soup.Status.OK) {
+        throw new FetchError.FAILED_REQUEST (@"Failed Request. HTTP Status: $(message.get_status())");
     }
 
     unowned uint8[] data = message_bytes.get_data ();


### PR DESCRIPTION
For porting the demo I followed the JavaScript implementation. Note that the Vala implementation is a bit different, because it handles exceptions. If the implementations should be as close to each other as possible this difference should be resolved eventually, I think.

Like in #62 I made all implementations use the Soup status instead of the status code to avoid magical numbers like `200`.

The Vala implementation didn't work for me, so I fixed it. There seems to be an underlying issue with how Vala code is formatted automatically:
```vala
@"https://api.wikimedia.org/feed/v1/wikipedia/$language/featured/$(date.format ("%Y/%m/%d"))";
```
gets formatted as
```vala
@"https://api.wikimedia.org/feed/v1/wikipedia/$language/featured/$(date.format (" % Y / % m / % d "))";
```
which doesn't work any more (due to the added spaces). I think the Vala formatting would have to be fixed in general, but I didn't attempt to do that, so I only fixed this demo.