### PR TITLE
Port 'Font Dialog' demo to Python

### DIFF
--- a/demos/Font Dialog/main.js
+++ b/demos/Font Dialog/main.js
@@ -3,12 +3,6 @@ import Gtk from "gi://Gtk";
 
 Gio._promisify(
   Gtk.FontDialog.prototype,
-  "choose_font_and_features",
-  "choose_font_and_features_finish",
-);
-
-Gio._promisify(
-  Gtk.FontDialog.prototype,
   "choose_family",
   "choose_family_finish",
 );
@@ -35,10 +29,10 @@ const dialog_custom = new Gtk.FontDialog({
 custom_button.connect("clicked", () => onClicked().catch(console.error));
 
 async function onClicked() {
-  const result = await dialog_custom.choose_family(
+  const family = await dialog_custom.choose_family(
     workbench.window,
     null,
     null,
   );
-  console.log(`Font Family: ${result.get_name()}`);
+  console.log(`Font Family: ${family.get_name()}`);
 }

--- a/demos/Font Dialog/main.py
+++ b/demos/Font Dialog/main.py
@@ -1,0 +1,36 @@
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gio, Gtk
+import workbench
+
+
+font_dialog_button = workbench.builder.get_object("font_dialog_button")
+custom_button = workbench.builder.get_object("custom_button")
+
+dialog_standard = Gtk.FontDialog(title="Select a Font", modal=True)
+font_dialog_button.set_dialog(dialog_standard)
+
+
+def on_font_description_changed(_button, _description):
+    font_name = font_dialog_button.get_font_desc().to_string()
+    print(f"Font: {font_name}")
+
+
+def on_clicked(_button):
+    dialog_custom.choose_family(workbench.window, None, None, on_family_chosen)
+
+
+def on_family_chosen(_dialog, result):
+    family = dialog_custom.choose_family_finish(result)
+    print(f"Font Family: {family.get_name()}")
+
+
+font_dialog_button.connect("notify::font-desc", on_font_description_changed)
+
+dialog_custom = Gtk.FontDialog(
+    title="Select a Font Family",
+    modal=True,
+)
+
+custom_button.connect("clicked", on_clicked)


### PR DESCRIPTION
I followed the Javascript implementation closely. The latter had some obsolete code in it (`choose_font_and_features` is never called) and I decided to rename `result` to `family` since `result` is already the default argument name for `choose_family_finish` needed for the Python implementation. The demo appears to work fine.
