### PR TITLE
Port 'Progress Bar' demo to Python

### DIFF
--- a/demos/Progress Bar/main.js
+++ b/demos/Progress Bar/main.js
@@ -1,4 +1,5 @@
 import Adw from "gi://Adw";
+import GLib from "gi://GLib";
 
 const first_bar = workbench.builder.get_object("first");
 const second_bar = workbench.builder.get_object("second");
@@ -33,30 +34,30 @@ function pulseProgress() {
   // Duration of animation
   const duration = 10000;
   const increment = pulse_period / duration;
-  const interval = setInterval(() => {
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, pulse_period, () => {
     if (counter >= 1.0) {
-      clearInterval(interval);
       counter = 0;
       second_bar.fraction = 0;
-      return;
+      return false;
     }
 
     second_bar.pulse();
     counter += increment;
-  }, pulse_period);
+    return true;
+  });
 }
 
 function updateTracker() {
   let time = 10;
-  const interval = setInterval(() => {
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
     if (time === 0) {
       progress_tracker.label = "";
-      clearInterval(interval);
       console.log("Operation complete!");
-      return;
+      return false;
     }
 
     progress_tracker.label = `${time} seconds remaining…`;
     time -= 1;
-  }, 1000);
+    return true;
+  });
 }

--- a/demos/Progress Bar/main.py
+++ b/demos/Progress Bar/main.py
@@ -1,0 +1,73 @@
+import gi
+
+gi.require_version("Adw", "1")
+from gi.repository import Adw, GLib
+import workbench
+
+first_bar = workbench.builder.get_object("first")
+second_bar = workbench.builder.get_object("second")
+play = workbench.builder.get_object("play")
+progress_tracker = workbench.builder.get_object("progress_tracker")
+
+target = Adw.PropertyAnimationTarget.new(first_bar, "fraction")
+
+animation = Adw.TimedAnimation(
+    widget=first_bar,
+    value_from=0.2,
+    value_to=1,
+    duration=11000,
+    easing=Adw.Easing.LINEAR,
+    target=target,
+)
+
+
+def on_play_clicked(_button):
+    animation.play()
+    update_tracker()
+    pulse_progress()
+
+
+animation.connect("done", lambda _: animation.reset())
+
+play.connect("clicked", on_play_clicked)
+
+
+def on_pulse():
+    global counter
+    if counter >= 1.0:
+        counter = 0
+        second_bar.set_fraction(0)
+        return False
+
+    second_bar.pulse()
+    counter += increment
+    return True
+
+
+def pulse_progress():
+    global counter, increment
+    counter = 0
+    # Time after which progress bar is pulsed
+    pulse_period = 500
+    # Duration of animation
+    duration = 10000
+    increment = pulse_period / duration
+    interval = GLib.timeout_add(pulse_period, on_pulse)
+
+
+def on_track_finished():
+    global time
+    if time == 0:
+        progress_tracker.set_label("")
+        print("Operation complete!")
+        return False
+
+    progress_tracker.set_label(f"{time} seconds remaining…")
+    time -= 1
+    return True
+
+
+def update_tracker():
+    global time
+    time = 10
+    interval = GLib.timeout_add(1000, on_track_finished)

--- a/demos/Progress Bar/main.py
+++ b/demos/Progress Bar/main.py
@@ -52,7 +52,7 @@ def pulse_progress():
     # Duration of animation
     duration = 10000
     increment = pulse_period / duration
-    interval = GLib.timeout_add(pulse_period, on_pulse)
+    GLib.timeout_add(pulse_period, on_pulse)
 
 
 def on_track_finished():
@@ -70,4 +70,4 @@ def on_track_finished():
 def update_tracker():
     global time
     time = 10
-    interval = GLib.timeout_add(1000, on_track_finished)
+    GLib.timeout_add(1000, on_track_finished)

--- a/demos/Progress Bar/main.py
+++ b/demos/Progress Bar/main.py
@@ -32,20 +32,18 @@ animation.connect("done", lambda _: animation.reset())
 play.connect("clicked", on_play_clicked)
 
 
-def on_pulse():
-    global counter
-    if counter >= 1.0:
-        counter = 0
-        second_bar.set_fraction(0)
-        return False
-
-    second_bar.pulse()
-    counter += increment
-    return True
-
-
 def pulse_progress():
-    global counter, increment
+    def on_pulse():
+        nonlocal counter
+        if counter >= 1.0:
+            counter = 0
+            second_bar.set_fraction(0)
+            return False
+
+        second_bar.pulse()
+        counter += increment
+        return True
+
     counter = 0
     # Time after which progress bar is pulsed
     pulse_period = 500
@@ -55,19 +53,17 @@ def pulse_progress():
     GLib.timeout_add(pulse_period, on_pulse)
 
 
-def on_track_finished():
-    global time
-    if time == 0:
-        progress_tracker.set_label("")
-        print("Operation complete!")
-        return False
-
-    progress_tracker.set_label(f"{time} seconds remaining…")
-    time -= 1
-    return True
-
-
 def update_tracker():
-    global time
+    def on_track_finished():
+        nonlocal time
+        if time == 0:
+            progress_tracker.set_label("")
+            print("Operation complete!")
+            return False
+
+        progress_tracker.set_label(f"{time} seconds remaining…")
+        time -= 1
+        return True
+
     time = 10
     GLib.timeout_add(1000, on_track_finished)


### PR DESCRIPTION
The demo works fine. I followed the Javascript implementation and replaced `setInterval()` by `GLib.timeout_add`. 

One question: Wouldn't it be better (for the sake of keeping different implementations close) if the Javascript implementation used the `GLib` function instead of a function which only exists in Javascript?