### PR TITLE
Fix HTTP Image demo for Rust

### DIFF
--- a/demos/HTTP Image/code.rs
+++ b/demos/HTTP Image/code.rs
@@ -29,7 +29,7 @@ async fn get_image_bytes(url: &str) -> glib::Bytes {
         .unwrap();
 
     if message.status() != Status::Ok {
-        panic!("Got {}, {:?}", message.status(), message.reason_phrase());
+        panic!("Got {:?}, {:?}", message.status(), message.reason_phrase());
     }
     image_bytes
 }


### PR DESCRIPTION
`message.status()` doesn't implement `Display` anymore