### PR TITLE
Wrap ListView and GridView in ScrolledWindow

### DIFF
--- a/src/List View Widgets/main.blp
+++ b/src/List View Widgets/main.blp
@@ -4,6 +4,7 @@ using Adw 1;
 Adw.StatusPage {
   title: _("List View Widgets");
   description: _("List and Grid views present a large dynamic list of model items");
+  valign: start;
 
   Adw.Clamp {
     maximum-size: 240;
@@ -57,7 +58,6 @@ Adw.StatusPage {
 
       Gtk.Stack stack {
         transition-type: crossfade;
-        hhomogeneous: false;
         vexpand: true;
 
         Gtk.StackPage {
@@ -69,8 +69,6 @@ Adw.StatusPage {
 
             ScrolledWindow {
               hscrollbar-policy: never;
-              vexpand: true;
-              hexpand: false;
               propagate-natural-height: true;
 
               ListView list_view {
@@ -101,15 +99,13 @@ Adw.StatusPage {
             valign: start;
 
             ScrolledWindow {
-              vexpand: true;
-              hexpand: false;
-              propagate-natural-height: true;
               hscrollbar-policy: never;
+              propagate-natural-height: true;
 
               GridView grid_view {
                 orientation: vertical;
-                max-columns: 4;
-                min-columns: 4;
+                max-columns: 2;
+                min-columns: 2;
                 enable-rubberband: true;
               }
             }


### PR DESCRIPTION
The demo did not work correctly: when creating more than 200 widgets and scrolling down, widgets are not dynamically created. Each `Gtk.ListView` or `Gtk.GridView` should be placed in `Gtk.ScrolledWindow` without intermediaries (Scrolling from `Adw.StatusPage` will not work)