### PR TITLE
[Vala] Port Radio buttons demo to Vala

### DIFF
--- a/src/Radio Buttons/main.vala
+++ b/src/Radio Buttons/main.vala
@@ -1,0 +1,16 @@
+#! /usr/bin/env -S vala workbench.vala --pkg gtk4
+public void main() {
+    var radio_button_1 = (Gtk.CheckButton) workbench.builder.get_object("radio_button_1");
+    var radio_button_2 = (Gtk.CheckButton) workbench.builder.get_object("radio_button_2");
+
+    radio_button_1.toggled.connect(() => {
+        if (radio_button_1.active) {
+            stdout.printf("Force Light Mode\n");
+        }
+    });
+    radio_button_2.toggled.connect(() => {
+        if (radio_button_2.active) {
+            stdout.printf("Force Dark Mode\n");
+        }
+    });
+}


### PR DESCRIPTION
This is to port the Radio buttons demo to Vala.
The changes have been tested on local machine, a screenshot of which is attached for reference.

![image](https://github.com/workbenchdev/demos/assets/106554051/4173802c-286a-4d46-a52f-eb1268b0a938)
