### PR TITLE
Only run workbench-cli ci on changed demos

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0 # required for make test
           submodules: "recursive"
 
       - name: Install host dependencies
@@ -25,13 +26,6 @@ jobs:
           key: ${{ runner.os }}-flatpak-dependencies-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-flatpak-dependencies-
-      - name: Restore .flatpak-builder
-        uses: actions/cache/restore@v3
-        with:
-          path: Workbench/.flatpak-builder
-          key: ${{ runner.os }}-flatpak-builder-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-flatpak-builder-
 
       - run: mutter --wayland --no-x11 --headless --wayland-display=wayland-0 --virtual-monitor 1280x720 > /tmp/mutter.log 2>&1 &
       - run: make ci
@@ -44,9 +38,3 @@ jobs:
         with:
           path: ~/.local/share/flatpak
           key: ${{ runner.os }}-flatpak-dependencies-${{ github.run_id }}
-      - name: Save .flatpak-builder
-        uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: Workbench/.flatpak-builder
-          key: ${{ runner.os }}-flatpak-builder-${{ github.run_id }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL:=/bin/bash -O globstar
-.PHONY: setup lint test ci
+.PHONY: setup test ci
 .DEFAULT_GOAL := ci
 
 setup:
@@ -7,22 +7,20 @@ setup:
 # flatpak remote-add --user --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
 	flatpak install --or-update --user --noninteractive flathub re.sonny.Workbench org.freedesktop.Sdk.Extension.rust-stable//23.08 org.freedesktop.Sdk.Extension.vala//23.08
 
-lint:
-# Rust
-	flatpak run --command="/usr/lib/sdk/rust-stable/bin/rustfmt" --filesystem=host re.sonny.Workbench --check --edition 2021 src/*/*.rs
-# Python
-# flatpak run --command="ruff" --filesystem=host re.sonny.Workbench check --config=../src/langs/python/ruff.toml src/*/*.py
-
 format:
 # npx prettier --write src/*/*.json
 	flatpak run --command="workbench-cli" --filesystem=host re.sonny.Workbench format javascript src/*/*.js
 	flatpak run --command="workbench-cli" --filesystem=host re.sonny.Workbench format css src/*/*.css
-# flatpak run --command="ruff" --filesystem=host re.sonny.Workbench format --config=../src/langs/python/ruff.toml src/**/*.py
-	flatpak run --command="/usr/lib/sdk/rust-stable/bin/rustfmt" --filesystem=host re.sonny.Workbench --edition 2021 src/*/*.rs
+	flatpak run --command="workbench-cli" --filesystem=host re.sonny.Workbench format python src/*/*.py
+	flatpak run --command="workbench-cli" --filesystem=host re.sonny.Workbench format rust src/*/*.rs
 	flatpak run --command="workbench-cli" --filesystem=host re.sonny.Workbench format blueprint src/*/*.blp
 	flatpak run --command="workbench-cli" --filesystem=host re.sonny.Workbench format vala src/*/*.vala
 
-test: lint
+test:
+# list folders that have changed and run workbench-cli ci on them
+	git diff --dirstat=files,0 origin/main src | sed 's/^[ 0-9.]\+% //g' | uniq | xargs -d '\n' flatpak run --command="workbench-cli" --filesystem=host re.sonny.Workbench ci
+
+all:
 	flatpak run --command="workbench-cli" --filesystem=host re.sonny.Workbench ci src/*
 
 ci: setup test

--- a/README.md
+++ b/README.md
@@ -23,22 +23,6 @@ flatpak override --user --filesystem=$PWD re.sonny.Workbench
 
 For more details see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-## Testing
-
-Please make sure to test your changes manually.
-
-You can run automated tests for a specific demo locally with
-
-```sh
-flatpak run --command="workbench-cli" --filesystem=$PWD/src re.sonny.Workbench ci src/Welcome
-```
-
-Or run all the tests locally with
-
-```sh
-make ci
-```
-
 ## Code of conduct
 
 Workbench follows the [GNOME Code of Conduct](https://conduct.gnome.org/).

--- a/src/Separator/Separator.vala
+++ b/src/Separator/Separator.vala
@@ -1,10 +1,10 @@
-#! /usr/bin/env -S vala workbench.vala --pkg gtk4 
+#! /usr/bin/env -S vala workbench.vala --pkg gtk4
 
 public void main () {
     var picture_one = (Gtk.Picture) workbench.builder.get_object ("picture_one");
     var picture_two = (Gtk.Picture) workbench.builder.get_object ("picture_two");
 
-    var file = File.new_for_uri(workbench.resolve("./image.png"));
+    var file = File.new_for_uri (workbench.resolve ("./image.png"));
 
     picture_one.file = file;
     picture_two.file = file;

--- a/src/Styling with CSS/main.vala
+++ b/src/Styling with CSS/main.vala
@@ -1,6 +1,6 @@
 #! /usr/bin/env -S vala workbench.vala --pkg gtk4
 
 public void main () {
-    var basic_label = workbench.builder.get_object("basic_label");
-    basic_label.add_css_class("css_text");
+    var basic_label = (Gtk.Label) workbench.builder.get_object ("basic_label");
+    basic_label.add_css_class ("css_text");
 }


### PR DESCRIPTION
Running `workbench-cli ci` on all demos takes a long time (~7'). That is caused by creating multiple language servers for each demo. Rust and Vala are particularly slow to bootstrap. 

Unfortunately, it's not possible to use one Vala language server for all demos because it doesn't support workspace folders.

This PR changes `make test` so that `workbench-cli ci` is called only with demos with changes compared to `main` instead of with every single demo.

This should also fix the intermittent CI failure that happens after a few minutes:

```
 **
GLib-GIO:ERROR:../gio/gdatainputstream.c:972:g_data_input_stream_read_complete: assertion failed (bytes == read_length): (-1 == 1)
Bail out! GLib-GIO:ERROR:../gio/gdatainputstream.c:972:g_data_input_stream_read_complete: assertion failed (bytes == read_length): (-1 == 1)
/app/bin/workbench-cli: line 22:     4 Aborted                 (core dumped) re.sonny.Workbench.cli "$@"
make: *** [Makefile:26: test] Error 134
Error: Process completed with exit code 2.
```