### PR TITLE
Port 'Font Dialog' to Vala

### DIFF
--- a/src/Font Dialog/main.vala
+++ b/src/Font Dialog/main.vala
@@ -1,0 +1,33 @@
+#! /usr/bin/env -S vala workbench.vala --pkg gtk4
+
+async void on_clicked (Gtk.FontDialog dialog_custom) {
+    var family = yield dialog_custom.choose_family (workbench.window, null, null);
+
+    message (@"Font Family: $(family.get_name())");
+}
+
+public void main () {
+    var font_dialog_button = (Gtk.FontDialogButton) workbench.builder.get_object ("font_dialog_button");
+    var custom_button = (Gtk.Button) workbench.builder.get_object ("custom_button");
+
+    Gtk.FontDialog dialog_standard = new Gtk.FontDialog () {
+        title = "Select a Font",
+        modal = true
+    };
+
+    font_dialog_button.dialog = dialog_standard;
+
+    font_dialog_button.notify["font-desc"].connect (() => {
+        var font_name = font_dialog_button.get_font_desc ().to_string ();
+        message (@"Font: $(font_name)");
+    });
+
+    Gtk.FontDialog dialog_custom = new Gtk.FontDialog () {
+        title = "Select a Font Family",
+        modal = true
+    };
+
+    custom_button.clicked.connect (() => {
+        on_clicked (dialog_custom);
+    });
+}


### PR DESCRIPTION
Added Vala code for Font Dialog

-Verify implementation of `async` and `yield` and function calls
-Do I need to enclose the function call into `try` and `catch` since there is a warning in the console

Let me know if there are any other changes or improvements