### PR TITLE
Port 'File Monitor' demo to Vala

### DIFF
--- a/src/File Monitor/main.vala
+++ b/src/File Monitor/main.vala
@@ -1,0 +1,84 @@
+#! /usr/bin/env -S vala workbench.vala --pkg libadwaita-1 --pkg gio-2.0
+
+private FileMonitor monitor_for_dir;
+private FileMonitor monitor_for_file;
+
+public void main () {
+
+    var edit_entry = (Gtk.TextView) workbench.builder.get_object ("edit_entry");
+    var view_file = (Gtk.Button) workbench.builder.get_object ("view_file");
+    var delete_file = (Gtk.Button) workbench.builder.get_object ("delete_file");
+    var edit_file = (Gtk.Button) workbench.builder.get_object ("edit_file");
+    var file_name = (Gtk.Label) workbench.builder.get_object ("file_name");
+    Gtk.TextBuffer buffer = edit_entry.get_buffer ();
+    File file = File.new_for_uri (workbench.resolve ("workbench.txt"));
+    File file_dir = file.get_parent ();
+    var overlay = (Adw.ToastOverlay) workbench.builder.get_object ("overlay");
+    var file_launcher = new Gtk.FileLauncher (file);
+    try {
+        FileInfo details = file.query_info (
+                                            "standard::display-name",
+                                            FileQueryInfoFlags.NONE,
+                                            null);
+        file_name.label = details.get_display_name ();
+        buffer.text = "Start editing ... ";
+        monitor_for_dir = file_dir.monitor (FileMonitorFlags.WATCH_MOVES, null);
+        monitor_for_file = file.monitor (FileMonitorFlags.NONE, null);
+    } catch (Error e) {
+        message (@"$(e.message)");
+    }
+
+    delete_file.clicked.connect (() => {
+        file.delete_async.begin (Priority.DEFAULT, null);
+    });
+
+    view_file.clicked.connect (() => {
+        file_launcher.launch.begin (workbench.window, null);
+    });
+
+    monitor_for_file.changed.connect ((file, other_file, event) => {
+        if (event == FileMonitorEvent.CHANGES_DONE_HINT) {
+            var toast = new Adw.Toast ("File modified") {
+                timeout = 2
+            };
+            overlay.add_toast (toast);
+        }
+    });
+
+    monitor_for_dir.changed.connect ((child, other_file, event) => {
+        var toast = new Adw.Toast ("") {
+            timeout = 2
+        };
+
+        switch (event) {
+            case FileMonitorEvent.RENAMED:
+                toast.title = @"$(child.get_basename()) was renamed to $(other_file.get_basename())";
+                break;
+            case FileMonitorEvent.DELETED:
+                toast.title = @"$(child.get_basename()) was deleted from the directory";
+                break;
+            case FileMonitorEvent.CREATED:
+                toast.title = @"$(child.get_basename()) created in the directory";
+                break;
+        }
+
+        if (toast.title != "")overlay.add_toast (toast);
+    });
+
+    edit_file.clicked.connect (() => {
+        string byte_string = buffer.text;
+        uint8[] bytes = byte_string.data;
+        try {
+            file.replace_contents (
+                                   bytes, // contents
+                                   null, // etag
+                                   false, // make_backup
+                                   FileCreateFlags.REPLACE_DESTINATION, // flags
+                                   null, // new_etag
+                                   null // cancellable
+            );
+        } catch (Error e) {
+            message (@"$(e.message)");
+        }
+    });
+}


### PR DESCRIPTION
Added Vala code for File Monitor

**Issues:**
- `File.replace_contents_async` does not work well and inserts non-readable text inside the workbench.txt file, it also shows an additional error stating that I don't have permission to open the the file.
- Using `File.replace_contents` instead seems to work correctly.
- The Python demo also has the same effect and uses the `async` method.

Screengrab of the error attached:

![Screenshot from 2024-06-11 19-14-28](https://github.com/workbenchdev/demos/assets/72352158/68d662c2-3209-428f-81be-77f4feda6a27)

Note: The Javascript demo works normally and it uses the `replace_contents_async` 

Let me know if there are any other issues with the code :)