### PR TITLE
Port 'Notification' demo to Vala

### DIFF
--- a/src/Notification/main.vala
+++ b/src/Notification/main.vala
@@ -1,0 +1,47 @@
+#! /usr/bin/env -S vala workbench.vala --pkg libadwaita-1 --pkg gio-2.0
+
+// private Gtk.Application application;
+
+public class Application : Gtk.Application {
+    public Application () {
+        Object (application_id: "testing.my.application",
+                flags: ApplicationFlags.FLAGS_NONE);
+    }
+}
+
+public void main () {
+    Application application = new Application ();
+
+    // https://gjs-docs.gnome.org/gio20/gio.notification
+    Notification notification = new Notification ("Lunch is ready");
+    notification.set_body ("Today we have pancakes and salad, and fruit and cake for dessert");
+    notification.set_default_action ("app.notification-reply");
+    notification.add_button ("Accept", "app.notification-accept");
+    notification.add_button ("Decline", "app.notification-decline");
+
+    var icon = new ThemedIcon ("object-rotate-right-symbolic");
+    notification.set_icon (icon);
+
+    var button_simple = (Gtk.Button) workbench.builder.get_object ("button_simple");
+    button_simple.clicked.connect (() => {
+        application.send_notification ("lunch-is-ready", notification);
+    });
+
+    SimpleAction action_reply = new SimpleAction ("notification-reply", null);
+    action_reply.activate.connect (() => {
+        message (@"Reply");
+    });
+    application.add_action (action_reply);
+
+    SimpleAction action_accept = new SimpleAction ("notification-accept", null);
+    action_accept.activate.connect (() => {
+        message (@"Accept");
+    });
+    application.add_action (action_accept);
+
+    SimpleAction action_decline = new SimpleAction ("notification-decline", null);
+    action_decline.activate.connect (() => {
+        message (@"Decline");
+    });
+    application.add_action (action_decline);
+}


### PR DESCRIPTION
Current issues:
- Demo runs, but on clicking the Trigger notification button presented with the error `"assertion 'g_application_get_is_registered (application)' failed"`
- Notification is not triggered

![Screenshot from 2024-06-12 12-40-23](https://github.com/workbenchdev/demos/assets/72352158/45179942-39a1-49c2-9aff-285f6075c2a0)

- Is the Application class declaration and object access the right way to do it?
- I also tried directly using a `Gtk.Application` variable which gives the same error. 

I'd appreciate any help :)