### PR TITLE
Use 'my_custom_class" for the programmaticaly set style

### DIFF
--- a/src/Styling with CSS/code.rs
+++ b/src/Styling with CSS/code.rs
@@ -3,5 +3,5 @@ use gtk::prelude::*;
 
 pub fn main() {
     let basic_label: gtk::Label = workbench::builder().object("basic_label").unwrap();
-    basic_label.add_css_class("css_text");
+    basic_label.add_css_class("my_custom_class");
 }


### PR DESCRIPTION
The "my_custom_class" style was unused, but was meant to style the last label