### PR TITLE
Use 'my_custom_class" for the programmaticaly set style

### DIFF
--- a/src/Styling with CSS/main.js
+++ b/src/Styling with CSS/main.js
@@ -1,3 +1,3 @@
 const basic_label = workbench.builder.get_object("basic_label");
 
-basic_label.add_css_class("css_text");
+basic_label.add_css_class("my_custom_class");


### PR DESCRIPTION
The "my_custom_class" style was unused, but was meant to style the last label