### PR TITLE
Use 'my_custom_class" for the programmaticaly set style

### DIFF
--- a/src/Styling with CSS/main.vala
+++ b/src/Styling with CSS/main.vala
@@ -2,5 +2,5 @@
 
 public void main () {
     var basic_label = (Gtk.Label) workbench.builder.get_object ("basic_label");
-    basic_label.add_css_class ("css_text");
+    basic_label.add_css_class ("my_custom_class");
 }


### PR DESCRIPTION
The "my_custom_class" style was unused, but was meant to style the last label