### PR TITLE
Fix Column View Python impl: sorting in year column

### DIFF
--- a/src/Column View/main.py
+++ b/src/Column View/main.py
@@ -28,8 +28,8 @@ class Book(GObject.Object):
     def author(self) -> str:
         return self._author
 
-    @GObject.Property(type=str)
-    def year(self) -> str:
+    @GObject.Property(type=int)
+    def year(self) -> int:
         return self._year
 
 


### PR DESCRIPTION
Sorting in the year column didn't work, as the data type string was not compatible with the NumericSorter. This is fixed by this PR.