### PR TITLE
Event Controller: Set propagation phase to capture

### DIFF
--- a/src/Event Controllers/main.js
+++ b/src/Event Controllers/main.js
@@ -44,6 +44,7 @@ ctrl_button.connect("clicked", () => {
 
 // Detect pointer button press and release events
 const gesture_click = new Gtk.GestureClick({ button: 0 });
+gesture_click.propagation_phase = Gtk.PropagationPhase.CAPTURE;
 
 window.add_controller(gesture_click);
 

--- a/src/Event Controllers/main.py
+++ b/src/Event Controllers/main.py
@@ -84,6 +84,7 @@ ctrl_button.connect("clicked", on_clicked)
 
 # Detect pointer button press and release events
 gesture_click = Gtk.GestureClick(button=0)
+gesture_click.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
 window.add_controller(gesture_click)
 gesture_click.connect("pressed", on_pressed)
 gesture_click.connect("released", on_released)

--- a/src/Event Controllers/main.vala
+++ b/src/Event Controllers/main.vala
@@ -47,6 +47,7 @@ public void main () {
     var gesture_click = new Gtk.GestureClick () {
         button = 0
     };
+    gesture_click.propagation_phase = Gtk.PropagationPhase.CAPTURE;
     ((Gtk.Widget) window).add_controller (gesture_click);
 
     gesture_click.pressed.connect ((gesture, n_press, x, y) => {


### PR DESCRIPTION
Fixes https://github.com/workbenchdev/demos/issues/222


button with "suggested-action" style

The reason that happens is that when clicking on a button, the button claims the "released" gesture
and we don't get the "released" signal.
Setting the propagation phase to "CAPTURE" allows
us to handle the event before the button claims
it.