### PR TITLE
Window: Make header bar flat

### DIFF
--- a/src/Window/main.blp
+++ b/src/Window/main.blp
@@ -7,8 +7,6 @@ Adw.Window window {
   title: _("My App");
 
   content: Adw.ToolbarView {
-    top-bar-style: raised;
-
     [top]
     Adw.HeaderBar {
       [end]


### PR DESCRIPTION
This small pull request makes the header bar flat in line with other GNOME apps in the Window demo.

![bilde](https://github.com/user-attachments/assets/bd466f0e-f55d-4c1d-b376-7a102dd48912)