### PR TITLE
Menu Button: Wrap long label

### DIFF
--- a/src/Menu Button/main.blp
+++ b/src/Menu Button/main.blp
@@ -50,6 +50,7 @@ Adw.StatusPage {
 
       Label {
         label: _("Displays view-specific items, typically used with hierarchical navigation and sidebars");
+        wrap: true;
       }
 
       ListBox {

--- a/src/Menu Button/main.blp
+++ b/src/Menu Button/main.blp
@@ -51,6 +51,7 @@ Adw.StatusPage {
       Label {
         label: _("Displays view-specific items, typically used with hierarchical navigation and sidebars");
         wrap: true;
+        justify: center;
       }
 
       ListBox {


### PR DESCRIPTION
Without wrapping the preview is too wide